### PR TITLE
'Single' radio buttons must not reset others

### DIFF
--- a/src/msw/radiobut.cpp
+++ b/src/msw/radiobut.cpp
@@ -92,7 +92,7 @@ void wxRadioButton::SetValue(bool value)
     else // owner drawn buttons don't react to this message
         Refresh();
 
-    if ( !value )
+    if ( !value || HasFlag(wxRB_SINGLE) )
         return;
 
     // if we set the value of one radio button we also must clear all the other


### PR DESCRIPTION
Radio buttons with `wxRB_SINGLE` style are not set initially. When getting set, the code attempts to unset other radio buttons that do not have `wxRB_GROUP | wxRB_SINGLE` style, and are immediately before or after a "single" button.